### PR TITLE
#9 Add command to remove load-balancer during example tear-down.

### DIFF
--- a/script/down
+++ b/script/down
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 CLUSTER="example"
+doctl compute load-balancer delete --force $(kubectl get svc doks-example -o jsonpath="{.metadata.annotations.kubernetes\.digitalocean\.com/load-balancer-id}")
 doctl k8s cluster delete ${CLUSTER}


### PR DESCRIPTION
We remove the load-balancer before the cluster as we use the k8s cluster metadata to get the load-balancer ID.